### PR TITLE
correction d'une faute d'orthographe

### DIFF
--- a/gmod/mettre un reboot automatique sur son serveur
+++ b/gmod/mettre un reboot automatique sur son serveur
@@ -1,10 +1,10 @@
 Hey, 
-Aujourd'Hui, je vais vous montrer comment mettre un reebot automatique.
+Aujourd'Hui, je vais vous montrer comment mettre un reboot automatique.
 
 Tous d'abord, il vous suffit d'accèdez au panel
 ♦ d'aller dans "Tâche Planifié"
 ♦ Cliquez sur "Ajouter"
-♦ Mettre comme nom "Reebot"
+♦ Mettre comme nom "Reboot"
 ♦ Mettre * dans "Jour de la semaine" et "Jour du mois"
 ♦ Cliquez sur l'heure que vous voulez (si vous voulez 2 fois, faites CTRL+Left Click sur les plages horaires)
 ♦ Mettre à "Après" "0" Secondes


### PR DESCRIPTION
on dit "reboot" on dit pas "reebbot"